### PR TITLE
Add support for file inputs and select dropdowns to theme customizer

### DIFF
--- a/src/app/theme/theme.component.html
+++ b/src/app/theme/theme.component.html
@@ -57,6 +57,13 @@
         <input type="text" [(ngModel)]="customization.value" style="float: left">
       </div>
 
+      <div *ngIf="customization.type == 'select'">
+        <label>{{ customization.name }}</label>
+        <select [(ngModel)]="customization.value">
+          <option *ngFor="let option of customization.options" [value]="option">{{ option }}</option>
+        </select>
+      </div>
+
   </div>
 
 </aside>

--- a/src/app/theme/theme.component.html
+++ b/src/app/theme/theme.component.html
@@ -52,6 +52,11 @@
         </select>
       </div>
 
+      <div *ngIf="customization.type == 'image'" class="image-picker-group">
+        <label>{{ customization.name }}  <a (click)="showImgSelect(customization.id)">{{ 'Select' | translate }}</a></label>
+        <input type="text" [(ngModel)]="customization.value" style="float: left">
+      </div>
+
   </div>
 
 </aside>
@@ -65,5 +70,7 @@
         <button (click)="save()" class="primary">{{ 'Save' | translate }}</button>
     </div>
 </footer>
+
+<respond-select-file [visible]="selectImgVisible" (onCancel)="reset()"  (onSelect)="imgSelected($event)" (onError)="failure($event)"></respond-select-file>
 
 <respond-drawer active="theme" [visible]="drawerVisible" (onHide)="reset()"></respond-drawer>

--- a/src/app/theme/theme.component.html
+++ b/src/app/theme/theme.component.html
@@ -52,7 +52,7 @@
         </select>
       </div>
 
-      <div *ngIf="customization.type == 'image'" class="image-picker-group">
+      <div *ngIf="customization.type == 'file'">
         <label>{{ customization.name }}  <a (click)="showImgSelect(customization.id)">{{ 'Select' | translate }}</a></label>
         <input type="text" [(ngModel)]="customization.value" style="float: left">
       </div>

--- a/src/app/theme/theme.component.ts
+++ b/src/app/theme/theme.component.ts
@@ -16,9 +16,11 @@ export class ThemeComponent {
   role: string;
   url: SafeResourceUrl;
   drawerVisible: boolean;
+  selectImgVisible: boolean = false;
+  selectImgControlTargetId: string = null;
+
   siteUrl: string;
 
-  
   settings: any = [];
 
   constructor (private _themeService: ThemeService, private _sanitizer: DomSanitizer, private _router: Router, private _appService: AppService) {}
@@ -31,7 +33,7 @@ export class ThemeComponent {
 
     this.id = localStorage.getItem('site_id');
     this.role = localStorage.getItem('site_role');
-   
+
     this.load();
     this.list('load');
 
@@ -80,7 +82,7 @@ export class ThemeComponent {
    */
   save () {
     var data = this.settings;
-    
+
     this._themeService.edit(data)
                      .subscribe(
                       (data: any) => { this.success(); this.list('save'); this.load(); },
@@ -89,7 +91,9 @@ export class ThemeComponent {
 
   }
 
-  reset() {}
+  reset() {
+    this.selectImgVisible = false;
+  }
 
   /**
    * Handles success
@@ -107,6 +111,22 @@ export class ThemeComponent {
     this.drawerVisible = !this.drawerVisible;
   }
 
+  showImgSelect(id: string) {
+    this.selectImgVisible = true;
+    this.selectImgControlTargetId = id;
+  }
+
+  /**
+   * image selected
+   */
+  imgSelected(event) {
+    // copy selected image to customizations model
+    const itemKey = Object.keys(this.settings.customizations).find(k => this.settings.customizations[k].id === this.selectImgControlTargetId);
+    this.settings.customizations[itemKey].value = event.url;
+
+    this.reset();
+  }
+
   /**
    * handles errors
    */
@@ -116,6 +136,8 @@ export class ThemeComponent {
 
     if(obj.status == 401) {
       this._router.navigate( ['/login'] );
+    } else {
+      this.reset();
     }
 
   }


### PR DESCRIPTION
This PR makes it possible to include theme customization fields of type "file".  The site admin can click a "select" button to open a file picker, or can enter a URL into a text field.  Here is a screenshot:

![image](https://user-images.githubusercontent.com/6088477/46634241-32690180-cb1e-11e8-8011-03f4e192d9e2.png)

