### PR TITLE
Change HTML structure for layout blocks

### DIFF
--- a/src/app/edit/add-block/add-block.component.ts
+++ b/src/app/edit/add-block/add-block.component.ts
@@ -48,48 +48,60 @@ export class AddBlockComponent {
     let html = '';
 
     if(type == '1-column') {
-      html = '<div class="block row  mt-5 mb-5">' +
+      html = '<div class="block">' +
+          '<div class="row">' +
           '<div class="col col-md-12"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+          '</div>' +
           '</div>';
     }
     else if(type == '2-column') {
-      html = '<div class="block row  mt-5 mb-5">' +
-        '<div class="col col-md-6"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' + 
-        '<div class="col col-md-6"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' + 
+      html = '<div class="block">' +
+        '<div class="row">' +
+        '<div class="col col-md-6"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+        '<div class="col col-md-6"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+        '</div>' +
         '</div>';
     }
     else if(type == '2-column-weighted-left') {
-      html = '<div class="block row  mt-5 mb-5">' +
+      html = '<div class="block">' +
+        '<div class="row">' +
         '<div class="col col-md-9"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
         '<div class="col col-md-3"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+        '</div>' +
         '</div>';
     }
     else if(type == '2-column-weighted-right') {
-      html = '<div class="block row mt-5 mb-5">' +
+      html = '<div class="block">' +
+        '<div class="row">' +
         '<div class="col col-md-3"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
         '<div class="col col-md-9"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+        '</div>' +
         '</div>';
     }
     else if(type == '3-column') {
-      html = '<div class="block row mt-5 mb-5">' +
+      html = '<div class="block">' +
+        '<div class="row">' +
         '<div class="col col-md-4"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
         '<div class="col col-md-4"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
         '<div class="col col-md-4"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+        '</div>' +
         '</div>';
     }
     else if(type == '4-column') {
-      html = '<div class="block row mt-5 mb-5">' +
+      html = '<div class="block">' +
+        '<div class="row">' +
         '<div class="col col-md-3"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
-        '<div class="col col-md-3"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' + 
         '<div class="col col-md-3"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
         '<div class="col col-md-3"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+        '<div class="col col-md-3"><h2>Cras justo odio</h2><p>Nullam id dolor id nibh</p></div>' +
+        '</div>' +
         '</div>';
     }
     else if(type == 'jumbotron') {
-      html = '<div class="block row jumbotron mt-5 mb-5"><div class="col col-md-12"><h1>Cras justo odio</h1><p>Nullam id dolor id nibh</p></div></div>';
+      html = '<div class="block row jumbotron"><div class="col col-md-12"><h1>Cras justo odio</h1><p>Nullam id dolor id nibh</p></div></div>';
     }
     else if(type == 'triple-feature') {
-      html = '<div class="row center-content mt-5 mb-5">' +
+      html = '<div class="row center-content">' +
       '<div class="col col-lg-4">' +
        ' <div><img class="rounded-circle" src="data:image/gif;base64,R0lGODlhAQABAIAAAHd3dwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" alt="Generic placeholder image" width="140" height="140"></div>' +
        '<h2>Donec ullamcorper</h2>' +
@@ -113,8 +125,9 @@ export class AddBlockComponent {
        '<!-- /.col-lg-4 -->' +
        '</div>';
     }
-    else if(type == 'featured-image-left') { 
-      html = '<div class="row featurette mt-5 mb-5">' +
+    else if(type == 'featured-image-left') {
+      html = '<div class="block featurette">' +
+        '<div class="row">' +
         '<div class="col col-md-7">' +
         '<h2 class="featurette-heading">Donec ullamcorper. <span class="text-muted">Vestibulum id ligula porta.</span></h2>' +
         '<p class="lead">Donec ullamcorper nulla non metus auctor fringilla. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur. Fusce dapibus, tellus ac cursus commodo.</p>' +
@@ -124,10 +137,13 @@ export class AddBlockComponent {
         '<div><img class="featurette-image img-fluid mx-auto" data-src="holder.js/500x500/auto" alt="500x500" style="width: 500px; height: 500px;" src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22500%22%20height%3D%22500%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20500%20500%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_161628f3224%20text%20%7B%20fill%3A%23AAAAAA%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A25pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_161628f3224%22%3E%3Crect%20width%3D%22500%22%20height%3D%22500%22%20fill%3D%22%23EEEEEE%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%22185.125%22%20y%3D%22261.1%22%3E500x500%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E" data-holder-rendered="true"></div>' +
         '</div>' +
         ' <!-- /.col-lg-5 -->' +
+        '</div>' +
+        ' <!-- /.row -->' +
         '</div>';
     }
-    else if(type == 'featured-image-right') { 
-        html = '<div class="row featurette mt-5 mb-5">' +
+    else if(type == 'featured-image-right') {
+      html = '<div class="block featurette">' +
+        '<div class="row">' +
           '<div class="col col-md-7 order-md-2">' +
           '<h2 class="featurette-heading">Donec ullamcorper. <span class="text-muted">Vestibulum id ligula porta.</span></h2>' +
           '<p class="lead">Donec ullamcorper nulla non metus auctor fringilla. Vestibulum id ligula porta felis euismod semper. Praesent commodo cursus magna, vel scelerisque nisl consectetur. Fusce dapibus, tellus ac cursus commodo.</p>' +
@@ -137,9 +153,11 @@ export class AddBlockComponent {
           '<div><img class="featurette-image img-fluid mx-auto" data-src="holder.js/500x500/auto" alt="500x500" style="width: 500px; height: 500px;" src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22500%22%20height%3D%22500%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20500%20500%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_161628f3224%20text%20%7B%20fill%3A%23AAAAAA%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A25pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_161628f3224%22%3E%3Crect%20width%3D%22500%22%20height%3D%22500%22%20fill%3D%22%23EEEEEE%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%22185.125%22%20y%3D%22261.1%22%3E500x500%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E" data-holder-rendered="true"></div>' +
           '</div>' +
           ' <!-- /.col-lg-5 -->' +
+          '</div>' +
+          ' <!-- /.row -->' +
           '</div>';
     }
-    
+
     this.onUpdate.emit({type: 'add-block', properties: {html: html}, attributes: []});
   }
 


### PR DESCRIPTION
I am building a theme that uses custom backgrounds on some layout blocks.  Because these backgrounds span the entire page width, I can't apply a Bootstrap container to the main content area.  However, I do want the width of the content to be constrained.

It is proving to be very difficult to pull off the layout I need, due to the HTML structure used for Respond layout blocks.  Here is the current structure:

    <div class="block row mt-5 mb-5">
        <div class="col col-md-12">
            <h2>Cras justo odio</h2>
            <p>Nullam id dolor id nibh</p>
        </div>
    </div>

This pull request changes the HTML structure to this:

    <div class="block">
        <div class="row">
            <div class="col col-md-12">
                <h2>Cras justo odio</h2>
                <p>Nullam id dolor id nibh</p>
            </div>
        </div>
    </div>

The modified structure will offer a lot more flexibility when styling layouts.  For example, to achieve the layout I described in my opening paragraph, I could simply apply a background to the block element and a `max-width:` constraint to the row element.

This change requires a corresponding change in the main respond repo, to make it so that settings in the left-column admin panel such as id, class, background image, etc. are applied to the block div rather than the row one.  I will submit a pull request for that momentarily.

I have tested this with various themes and it works great, with no modifications needed to the themes or to their CSS.
