### PR TITLE
Add support for file input fields in plugins

### DIFF
--- a/src/app/edit/edit-element/edit-element.component.html
+++ b/src/app/edit/edit-element/edit-element.component.html
@@ -2,7 +2,7 @@
 
   <form (ngSubmit)="submit()" #addForm="ngForm" ngNativeValidate>
 
-    <h4 *ngIf="showRemove == false" (click)="toggleIsExpanded()" [class.collapsed]="isExpanded == false">{{ 'Element' | translate }} 
+    <h4 *ngIf="showRemove == false" (click)="toggleIsExpanded()" [class.collapsed]="isExpanded == false">{{ 'Element' | translate }}
       <i *ngIf="isExpanded == false" class="expand-icon material-icons">expand_more</i>
       <i *ngIf="isExpanded == true" class="expand-icon material-icons">expand_less</i>
     </h4>
@@ -58,7 +58,7 @@
           </div>
 
           <div *ngSwitchCase="'select'">
-            <label>{{attribute.label | translate }}</label>
+            <label>{{attribute.label | translate }}</label>headline
             <select id="{{attribute.attr}}" name="{{attribute.attr}}" [(ngModel)]="attribute.value" (change)="submit()">
               <option *ngFor="let value of attribute.values" [value]="value">{{value}}</option>
             </select>
@@ -99,6 +99,11 @@
             </select>
           </div>
 
+          <div *ngSwitchCase="'file'">
+            <label>{{attribute.label | translate }} <a (click)="showSelect(attribute.attr)">{{ 'Select' | translate }}</a></label>
+            <input type="text" id="{{attribute.attr}}" name="{{attribute.attr}}" [(ngModel)]="attribute.value" (change)="submit()">
+          </div>
+
         </div>
 
       </div>
@@ -113,5 +118,7 @@
     </div>
 
   </form>
-  
+
 </div>
+
+<respond-select-file [visible]="selectVisible" (onCancel)="reset()"  (onSelect)="select($event)" (onError)="failure($event)"></respond-select-file>

--- a/src/app/edit/edit-element/edit-element.component.ts
+++ b/src/app/edit/edit-element/edit-element.component.ts
@@ -17,6 +17,8 @@ export class EditElementComponent {
   isExpanded: boolean = true;
   isHtmlExpanded: boolean = false;
   showRemove: boolean = false;
+  selectVisible: boolean = false;
+  _selectAttr: string = '';
 
   // lists
   forms: any = [];
@@ -104,22 +106,22 @@ export class EditElementComponent {
             else if(attributes[x].values[0] == 'respond.galleries') {
               attributes[x].type = 'gallery';
               this.listGalleries();
-            } 
+            }
             else if(attributes[x].values[0] == 'respond.pages') {
               attributes[x].type = 'page';
               this.listPages();
-            } 
+            }
             else if(attributes[x].values[0] == 'respond.components') {
               attributes[x].type = 'component';
               this.listComponents();
-            } 
+            }
             else if(attributes[x].values[0] == 'respond.products') {
               attributes[x].type = 'product';
               this.listProducts();
-            } 
+            }
           }
 
-      } 
+      }
 
     }
 
@@ -153,12 +155,49 @@ export class EditElementComponent {
     this.onCancel.emit(null);
   }
 
+  /*
+   * shows the select file modal
+   */
+  showSelect(attr: string) {
+    this.selectVisible = true;
+    this._selectAttr = attr;
+  }
+
   /**
    * Resets any transitional states
    */
   reset() {
     this.showRemove = false;
     this.isHtmlExpanded = false;
+    this.selectVisible = false;
+    this._selectAttr = '';
+  }
+
+  /**
+   * select file
+   */
+  select(event) {
+
+    // Walk through attributes and find the one for which the file select dialog was called
+    for(let x=0; x<this._attributes.length; x++) {
+      if (this._attributes[x].attr == this._selectAttr) {
+        this._attributes[x].value = 'files/' + event.name;
+      }
+    }
+
+    // reset
+    this.reset();
+
+    // submit
+    this.submit();
+  }
+
+  /**
+   * failure
+   */
+  failure(event) {
+    // reset
+    this.reset();
   }
 
   /**


### PR DESCRIPTION
This adds support for file/image select dialogs in plugins.  My use case is a plugin that allows my client to create page elements like this one:

![image](https://user-images.githubusercontent.com/6088477/48985625-7072b280-f0d7-11e8-95a3-a96860bfe4c1.png)

My plugin has fields for headline, subheadline, button text, button URL, and background image.